### PR TITLE
Add a Download button that splices the sentence into one WAV

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,6 +15,17 @@ function syncUrlState(tags) {
   urlState.set(tags.map((tag) => tag.id));
 }
 
+function toFileName(words) {
+  const slug = words
+    .join(" ")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60);
+
+  return "vox-" + (slug || "sentence") + ".wav";
+}
+
 export default class App extends React.Component {
   state = {
     history: [],
@@ -22,6 +33,7 @@ export default class App extends React.Component {
       id: word.toLowerCase(),
     })),
     suggestions: vox.words.map((word) => ({ id: word })),
+    isDownloading: false,
   };
 
   handleDelete = (i) => {
@@ -69,6 +81,30 @@ export default class App extends React.Component {
     this.setState({ tags: nextTags }, () => {
       syncUrlState(this.state.tags);
     });
+  };
+
+  handleDownload = async () => {
+    const words = this.state.tags.map((tag) => tag.id);
+    if (words.length === 0) return;
+
+    this.setState({ isDownloading: true });
+    try {
+      const wav = await vox.getSentenceWav(words);
+      if (wav == null) return;
+
+      const url = URL.createObjectURL(wav);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = toFileName(words);
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      this.setState({ isDownloading: false });
+    }
   };
 
   componentDidMount() {
@@ -147,6 +183,13 @@ export default class App extends React.Component {
           }}
         >
           Play
+        </button>
+        <button
+          className="download"
+          disabled={tags.length === 0 || this.state.isDownloading}
+          onClick={this.handleDownload}
+        >
+          {this.state.isDownloading ? "Rendering…" : "Download"}
         </button>
       </>
     );

--- a/src/index.css
+++ b/src/index.css
@@ -174,6 +174,28 @@ body {
   font-family: inherit;
 }
 
+.download {
+  margin-top: 8px;
+  margin-left: 8px;
+
+  border-top-color: #667359;
+  border-left-color: #667359;
+  background-color: #445435;
+  border-bottom-color: #1f2719;
+  border-right-color: #1f2719;
+  color: rgba(255, 255, 255, 0.75);
+
+  padding: 4px;
+  font-size: inherit;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.download:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 mark {
   background-color: #667359;
 }

--- a/src/vox.js
+++ b/src/vox.js
@@ -669,6 +669,137 @@ function playAudioBufferAt(buffer, startTime) {
   source.start(startTime);
 }
 
+const loadedWordFilesByWord = new Map();
+
+function loadWordFile(word) {
+  let promise = loadedWordFilesByWord.get(word);
+  if (promise == null) {
+    promise = fetch("/vox/" + sounds[word])
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error("Failed to fetch " + sounds[word]);
+        }
+        return response.arrayBuffer();
+      })
+      .catch((err) => {
+        console.error(err);
+        loadedWordFilesByWord.delete(word);
+        return null;
+      });
+    loadedWordFilesByWord.set(word, promise);
+  }
+  return promise;
+}
+
+// Pulls the format and the raw PCM bytes out of a WAV. No decoding happens
+// here: the samples stay exactly as they are on disk.
+function parseWav(arrayBuffer) {
+  const view = new DataView(arrayBuffer);
+  if (view.getUint32(0, false) !== 0x52494646) return null; // "RIFF"
+  if (view.getUint32(8, false) !== 0x57415645) return null; // "WAVE"
+
+  let format = null;
+  let pcm = null;
+  let offset = 12;
+  while (offset + 8 <= view.byteLength) {
+    const chunkId = view.getUint32(offset, false);
+    const chunkSize = view.getUint32(offset + 4, true);
+    const body = offset + 8;
+
+    if (chunkId === 0x666d7420 && chunkSize >= 16) {
+      // "fmt "
+      format = {
+        channels: view.getUint16(body + 2, true),
+        sampleRate: view.getUint32(body + 4, true),
+        bitsPerSample: view.getUint16(body + 14, true),
+      };
+    } else if (chunkId === 0x64617461) {
+      // "data"
+      pcm = new Uint8Array(
+        arrayBuffer,
+        body,
+        Math.min(chunkSize, view.byteLength - body)
+      );
+    }
+
+    offset = body + chunkSize + (chunkSize % 2);
+  }
+
+  if (format == null || pcm == null) return null;
+  return { ...format, pcm };
+}
+
+// Linear interpolation over samples. Only needed for the handful of effects
+// that were recorded at a different sample rate than the speech.
+function resamplePcm(pcm, fromRate, toRate) {
+  if (fromRate === toRate) return pcm;
+
+  const ratio = toRate / fromRate;
+  const resampled = new Uint8Array(Math.floor(pcm.length * ratio));
+  for (let i = 0; i < resampled.length; i++) {
+    const position = i / ratio;
+    const left = Math.floor(position);
+    const right = Math.min(left + 1, pcm.length - 1);
+    const weight = position - left;
+    resampled[i] = Math.round(pcm[left] * (1 - weight) + pcm[right] * weight);
+  }
+  return resampled;
+}
+
+function mostCommonSampleRate(segments) {
+  const counts = new Map();
+  for (let i = 0; i < segments.length; i++) {
+    const rate = segments[i].sampleRate;
+    counts.set(rate, (counts.get(rate) || 0) + 1);
+  }
+
+  let best = segments[0].sampleRate;
+  let bestCount = 0;
+  counts.forEach((count, rate) => {
+    if (count > bestCount || (count === bestCount && rate < best)) {
+      best = rate;
+      bestCount = count;
+    }
+  });
+  return best;
+}
+
+// Wraps the joined samples in a single WAV header. Again, no encoding: the
+// samples are copied straight through into the data chunk.
+function encodeWav(parts, sampleRate, channels, bitsPerSample) {
+  const dataSize = parts.reduce((total, part) => total + part.length, 0);
+  const blockAlign = channels * (bitsPerSample / 8);
+  const buffer = new ArrayBuffer(44 + dataSize);
+  const view = new DataView(buffer);
+
+  function writeAscii(offset, text) {
+    for (let i = 0; i < text.length; i++) {
+      view.setUint8(offset + i, text.charCodeAt(i));
+    }
+  }
+
+  writeAscii(0, "RIFF");
+  view.setUint32(4, 36 + dataSize, true);
+  writeAscii(8, "WAVE");
+  writeAscii(12, "fmt ");
+  view.setUint32(16, 16, true); // PCM fmt chunk is always 16 bytes
+  view.setUint16(20, 1, true); // format: PCM
+  view.setUint16(22, channels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * blockAlign, true); // byte rate
+  view.setUint16(32, blockAlign, true);
+  view.setUint16(34, bitsPerSample, true);
+  writeAscii(36, "data");
+  view.setUint32(40, dataSize, true);
+
+  let offset = 44;
+  for (let i = 0; i < parts.length; i++) {
+    new Uint8Array(buffer, offset, parts[i].length).set(parts[i]);
+    offset += parts[i].length;
+  }
+  return buffer;
+}
+
 const vox = {
   words: Object.keys(sounds),
   async playWord(word) {
@@ -688,6 +819,33 @@ const vox = {
       playAudioBufferAt(buffer, nextStart);
       nextStart += buffer.duration;
     }
+  },
+  // Joins the words into one WAV by concatenating their PCM data. Nothing is
+  // decoded or re-encoded, so the download is bit-for-bit the same audio the
+  // site plays. Returns null when none of the words could be loaded.
+  async getSentenceWav(words) {
+    const files = await Promise.all(words.map(loadWordFile));
+    const segments = files.map((file) => file && parseWav(file)).filter(Boolean);
+    if (segments.length === 0) return null;
+
+    const { channels, bitsPerSample } = segments[0];
+    const mismatched = segments.some(
+      (segment) =>
+        segment.channels !== channels ||
+        segment.bitsPerSample !== bitsPerSample
+    );
+    if (mismatched) {
+      throw new Error("Cannot join words with different channel or bit depths");
+    }
+
+    const sampleRate = mostCommonSampleRate(segments);
+    const parts = segments.map((segment) =>
+      resamplePcm(segment.pcm, segment.sampleRate, sampleRate)
+    );
+
+    return new Blob([encodeWav(parts, sampleRate, channels, bitsPerSample)], {
+      type: "audio/wav",
+    });
   },
 };
 

--- a/src/vox.js
+++ b/src/vox.js
@@ -814,11 +814,11 @@ const vox = {
     );
     const ctx = getContext();
     let nextStart = ctx.currentTime;
-    for (const buffer of buffers) {
-      if (buffer == null) continue;
+    buffers.forEach((buffer) => {
+      if (buffer == null) return;
       playAudioBufferAt(buffer, nextStart);
       nextStart += buffer.duration;
-    }
+    });
   },
   // Joins the words into one WAV by concatenating their PCM data. Nothing is
   // decoded or re-encoded, so the download is bit-for-bit the same audio the


### PR DESCRIPTION
## What
Adds a **Download** button next to **Play**. It takes the current sentence (the typed tags), concatenates each word's audio clip into a single WAV file, and triggers a browser download. The join is purely byte-level: parse each WAV header, concatenate the raw PCM samples, re-wrap in a single WAV header, nothing is decoded or re-encoded, so the output is bit-for-bit the audio the site already plays.

Sample-rate differences between clips are handled by resampling to the most common rate; clips that differ in channel count or bit depth are rejected with a clear error (mixing those isn't meaningful).

## Changes
- `src/vox.js`: `loadWordFile` + `parseWav` / `resamplePcm` / `mostCommonSampleRate` / `encodeWav` helpers, and `vox.getSentenceWav(words)`.
- `src/App.js`: `isDownloading` state, `handleDownload`, and the **Download** button.
- `src/index.css`: styling for the new button.

Deliberately avoided `for...of` in the new code so it stays clean under the babel-eslint version CRA pins.

Tested locally with `CI=true yarn build` (the same lint-as-error gate Netlify uses) compiles cleanly.